### PR TITLE
.cloned()'ed

### DIFF
--- a/src/branch.rs
+++ b/src/branch.rs
@@ -124,7 +124,8 @@ macro_rules! alt (
 
   (__impl $i:expr, $subrule:ident!( $($args:tt)*) | $($rest:tt)*) => (
     {
-      let res = $subrule!($i, $($args)*);
+      let i_ = $i.clone();
+      let res = $subrule!(i_, $($args)*);
       match res {
         $crate::IResult::Done(_,_)     => res,
         $crate::IResult::Incomplete(_) => res,
@@ -135,7 +136,8 @@ macro_rules! alt (
 
   (__impl $i:expr, $subrule:ident!( $($args:tt)* ) => { $gen:expr } | $($rest:tt)+) => (
     {
-      match $subrule!( $i, $($args)* ) {
+      let i_ = $i.clone();
+      match $subrule!(i_, $($args)* ) {
         $crate::IResult::Done(i,o)     => $crate::IResult::Done(i,$gen(o)),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Error(_)      => {
@@ -155,7 +157,8 @@ macro_rules! alt (
 
   (__impl $i:expr, $subrule:ident!( $($args:tt)* ) => { $gen:expr }) => (
     {
-      match $subrule!( $i, $($args)* ) {
+      let i_ = $i.clone();
+      match $subrule!(i_, $($args)* ) {
         $crate::IResult::Done(i,o)     => $crate::IResult::Done(i,$gen(o)),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Error(_)      => {
@@ -171,7 +174,8 @@ macro_rules! alt (
 
   (__impl $i:expr, $subrule:ident!( $($args:tt)*)) => (
     {
-      match $subrule!( $i, $($args)* ) {
+      let i_ = $i.clone();
+      match $subrule!(i_, $($args)* ) {
         $crate::IResult::Done(i,o)     => $crate::IResult::Done(i,o),
         $crate::IResult::Incomplete(x) => $crate::IResult::Incomplete(x),
         $crate::IResult::Error(_)      => {
@@ -207,7 +211,8 @@ macro_rules! alt_complete (
 
   ($i:expr, $subrule:ident!( $($args:tt)*) | $($rest:tt)*) => (
     {
-      let res = complete!($i, $subrule!($($args)*));
+      let i_ = $i.clone();
+      let res = complete!(i_, $subrule!($($args)*));
       match res {
         $crate::IResult::Done(_,_) => res,
         _ => alt_complete!($i, $($rest)*),
@@ -217,7 +222,8 @@ macro_rules! alt_complete (
 
   ($i:expr, $subrule:ident!( $($args:tt)* ) => { $gen:expr } | $($rest:tt)+) => (
     {
-      match complete!($i, $subrule!($($args)*)) {
+      let i_ = $i.clone();
+      match complete!(i_, $subrule!($($args)*)) {
         $crate::IResult::Done(i,o) => $crate::IResult::Done(i,$gen(o)),
         _ => alt_complete!($i, $($rest)*),
       }
@@ -328,7 +334,8 @@ macro_rules! alt_complete (
 macro_rules! switch (
   (__impl $i:expr, $submac:ident!( $($args:tt)* ), $($p:pat => $subrule:ident!( $($args2:tt)* ))|* ) => (
     {
-      match map!($i, $submac!($($args)*), |o| Some(o)) {
+      let i_ = $i.clone();
+      match map!(i_, $submac!($($args)*), |o| Some(o)) {
         $crate::IResult::Error(e)      => $crate::IResult::Error(error_node_position!(
             $crate::ErrorKind::Switch, $i, e
         )),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -352,8 +352,9 @@ macro_rules! apply (
 macro_rules! return_error (
   ($i:expr, $code:expr, $submac:ident!( $($args:tt)* )) => (
     {
+      let i_ = $i.clone();
       let cl = || {
-        $submac!($i, $($args)*)
+        $submac!(i_, $($args)*)
       };
 
       match cl() {
@@ -433,7 +434,8 @@ macro_rules! add_return_error (
 macro_rules! complete (
   ($i:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      match $submac!($i, $($args)*) {
+      let i_ = $i.clone();
+      match $submac!(i_, $($args)*) {
         $crate::IResult::Done(i, o)    => $crate::IResult::Done(i, o),
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete(_) =>  {
@@ -525,7 +527,8 @@ macro_rules! map_res (
   // Internal parser, do not use directly
   (__impl $i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
-      match $submac!($i, $($args)*) {
+      let i_ = $i.clone();
+      match $submac!(i_, $($args)*) {
         $crate::IResult::Error(e)                            => $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) => $crate::IResult::Incomplete($crate::Needed::Unknown),
         $crate::IResult::Incomplete($crate::Needed::Size(i)) => $crate::IResult::Incomplete($crate::Needed::Size(i)),
@@ -557,7 +560,8 @@ macro_rules! map_opt (
   // Internal parser, do not use directly
   (__impl $i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
-      match $submac!($i, $($args)*) {
+      let i_ = $i.clone();
+      match $submac!(i_, $($args)*) {
         $crate::IResult::Error(e)                            => $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) => $crate::IResult::Incomplete($crate::Needed::Unknown),
         $crate::IResult::Incomplete($crate::Needed::Size(i)) => $crate::IResult::Incomplete($crate::Needed::Size(i)),
@@ -617,7 +621,8 @@ macro_rules! verify (
   // Internal parser, do not use directly
   (__impl $i:expr, $submac:ident!( $($args:tt)* ), $submac2:ident!( $($args2:tt)* )) => (
     {
-      match $submac!($i, $($args)*) {
+      let i_ = $i.clone();
+      match $submac!(i_, $($args)*) {
         $crate::IResult::Error(e)                            => $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) => $crate::IResult::Incomplete($crate::Needed::Unknown),
         $crate::IResult::Incomplete($crate::Needed::Size(i)) => $crate::IResult::Incomplete($crate::Needed::Size(i)),
@@ -765,7 +770,8 @@ macro_rules! expr_opt (
 macro_rules! opt(
   ($i:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      match $submac!($i, $($args)*) {
+      let i_ = $i.clone();
+      match $submac!(i_, $($args)*) {
         $crate::IResult::Done(i,o)     => $crate::IResult::Done(i, ::std::option::Option::Some(o)),
         $crate::IResult::Error(_)      => $crate::IResult::Done($i, ::std::option::Option::None),
         $crate::IResult::Incomplete(i) => $crate::IResult::Incomplete(i)
@@ -801,7 +807,8 @@ macro_rules! opt(
 macro_rules! opt_res (
   ($i:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      match $submac!($i, $($args)*) {
+      let i_ = $i.clone();
+      match $submac!(i_, $($args)*) {
         $crate::IResult::Done(i,o)     => $crate::IResult::Done(i,  ::std::result::Result::Ok(o)),
         $crate::IResult::Error(e)      => $crate::IResult::Done($i, ::std::result::Result::Err(e)),
         $crate::IResult::Incomplete(i) => $crate::IResult::Incomplete(i)
@@ -904,7 +911,8 @@ macro_rules! cond(
   ($i:expr, $cond:expr, $submac:ident!( $($args:tt)* )) => (
     {
       if $cond {
-        match $submac!($i, $($args)*) {
+        let i_ = $i.clone();
+        match $submac!(i_, $($args)*) {
           $crate::IResult::Done(i,o)     => $crate::IResult::Done(i, ::std::option::Option::Some(o)),
           $crate::IResult::Error(_)      => $crate::IResult::Done($i, ::std::option::Option::None),
           $crate::IResult::Incomplete(i) => $crate::IResult::Incomplete(i)
@@ -990,7 +998,8 @@ macro_rules! cond_reduce(
 macro_rules! peek(
   ($i:expr, $submac:ident!( $($args:tt)* )) => (
     {
-      match $submac!($i, $($args)*) {
+      let i_ = $i.clone();
+      match $submac!(i_, $($args)*) {
         $crate::IResult::Done(_,o)     => $crate::IResult::Done($i, o),
         $crate::IResult::Error(a)      => $crate::IResult::Error(a),
         $crate::IResult::Incomplete(i) => $crate::IResult::Incomplete(i)
@@ -1031,7 +1040,8 @@ macro_rules! not(
   ($i:expr, $submac:ident!( $($args:tt)* )) => (
     {
       use $crate::Slice;
-      match $submac!($i, $($args)*) {
+      let i_ = $i.clone();
+      match $submac!(i_, $($args)*) {
         $crate::IResult::Done(_, _)    => $crate::IResult::Error(error_position!($crate::ErrorKind::Not, $i)),
         $crate::IResult::Error(_)      => $crate::IResult::Done($i, ($i).slice(..0)),
         $crate::IResult::Incomplete(_) => $crate::IResult::Done($i, ($i).slice(..0))
@@ -1096,7 +1106,7 @@ macro_rules! eof (
   );
 );
 
-/// `recognize!(&[T] -> IResult<&[T], O> ) => &[T] -> IResult<&[T], &[T]>`
+/// `recognize!(I -> IResult<I, O> ) => I -> IResult<I, I>`
 /// if the child parser was successful, return the consumed input as produced value
 ///
 /// ```
@@ -1114,9 +1124,10 @@ macro_rules! recognize (
     {
       use $crate::Offset;
       use $crate::Slice;
-      match $submac!($i, $($args)*) {
+      let i_ = $i.clone();
+      match $submac!(i_, $($args)*) {
         $crate::IResult::Done(i,_)     => {
-          let index = ($i).offset(i);
+          let index = (&$i).offset(&i);
           $crate::IResult::Done(i, ($i).slice(..index))
         },
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -10,10 +10,11 @@ macro_rules! separated_list(
 
       //FIXME: use crate vec
       let mut res   = ::std::vec::Vec::new();
-      let mut input = $i;
+      let mut input = $i.clone();
 
       // get the first element
-      match $submac!(input, $($args2)*) {
+      let input_ = input.clone();
+      match $submac!(input_, $($args2)*) {
         $crate::IResult::Error(_)      => $crate::IResult::Done(input, ::std::vec::Vec::new()),
         $crate::IResult::Incomplete(i) => $crate::IResult::Incomplete(i),
         $crate::IResult::Done(i,o)     => {
@@ -25,13 +26,15 @@ macro_rules! separated_list(
 
             loop {
               // get the separator first
-              if let $crate::IResult::Done(i2,_) = $sep!(input, $($args)*) {
+              let input_ = input.clone();
+              if let $crate::IResult::Done(i2,_) = $sep!(input_, $($args)*) {
                 if i2.input_len() == input.input_len() {
                   break;
                 }
 
                 // get the element next
-                if let $crate::IResult::Done(i3,o3) = $submac!(i2, $($args2)*) {
+                let i2_ = i2.clone();
+                if let $crate::IResult::Done(i3,o3) = $submac!(i2_, $($args2)*) {
                   if i3.input_len() == i2.input_len() {
                     break;
                   }
@@ -70,10 +73,11 @@ macro_rules! separated_nonempty_list(
       use $crate::InputLength;
 
       let mut res   = ::std::vec::Vec::new();
-      let mut input = $i;
+      let mut input = $i.clone();
 
       // get the first element
-      match $submac!(input, $($args2)*) {
+      let input_ = input.clone();
+      match $submac!(input_, $($args2)*) {
         $crate::IResult::Error(a)      => $crate::IResult::Error(a),
         $crate::IResult::Incomplete(i) => $crate::IResult::Incomplete(i),
         $crate::IResult::Done(i,o)     => {
@@ -84,12 +88,14 @@ macro_rules! separated_nonempty_list(
             input = i;
 
             loop {
-              if let $crate::IResult::Done(i2,_) = $sep!(input, $($args)*) {
+              let input_ = input.clone();
+              if let $crate::IResult::Done(i2,_) = $sep!(input_, $($args)*) {
                 if i2.input_len() == input.input_len() {
                   break;
                 }
-
-                if let $crate::IResult::Done(i3,o3) = $submac!(i2, $($args2)*) {
+                
+                let i2_ = i2.clone();
+                if let $crate::IResult::Done(i3,o3) = $submac!(i2_, $($args2)*) {
                   if i3.input_len() == i2.input_len() {
                     break;
                   }
@@ -147,7 +153,7 @@ macro_rules! many0(
 
       let ret;
       let mut res   = ::std::vec::Vec::new();
-      let mut input = $i;
+      let mut input = $i.clone();
 
       loop {
         if input.input_len() == 0 {
@@ -155,7 +161,8 @@ macro_rules! many0(
           break;
         }
 
-        match $submac!(input, $($args)*) {
+        let input_ = input.clone();
+        match $submac!(input_, $($args)*) {
           $crate::IResult::Error(_)                            => {
             ret = $crate::IResult::Done(input, res);
             break;
@@ -220,7 +227,8 @@ macro_rules! many1(
   ($i:expr, $submac:ident!( $($args:tt)* )) => (
     {
       use $crate::InputLength;
-      match $submac!($i, $($args)*) {
+      let i_ = $i.clone();
+      match $submac!(i_, $($args)*) {
         $crate::IResult::Error(_)      => $crate::IResult::Error(
           error_position!($crate::ErrorKind::Many1,$i)
         ),
@@ -239,7 +247,8 @@ macro_rules! many1(
               if input.input_len() == 0 {
                 break;
               }
-              match $submac!(input, $($args)*) {
+              let input_ = input.clone();
+              match $submac!(input_, $($args)*) {
                 $crate::IResult::Error(_)                    => {
                   break;
                 },
@@ -315,7 +324,7 @@ macro_rules! many_till(
 
       let ret;
       let mut res   = ::std::vec::Vec::new();
-      let mut input = $i;
+      let mut input = $i.clone();
 
       loop {
         match $submac2!(input, $($args2)*) {
@@ -396,13 +405,14 @@ macro_rules! many_m_n(
     {
       use $crate::InputLength;
       let mut res          = ::std::vec::Vec::with_capacity($m);
-      let mut input        = $i;
+      let mut input        = $i.clone();
       let mut count: usize = 0;
       let mut err          = false;
       let mut incomplete: ::std::option::Option<$crate::Needed> = ::std::option::Option::None;
       loop {
         if count == $n { break }
-        match $submac!(input, $($args)*) {
+        let i_ = input.clone();
+        match $submac!(i_, $($args)*) {
           $crate::IResult::Done(i, o) => {
             // do not allow parsers that do not consume input (causes infinite loops)
             if i.input_len() == input.input_len() {
@@ -421,7 +431,7 @@ macro_rules! many_m_n(
             break;
           },
           $crate::IResult::Incomplete($crate::Needed::Size(i)) => {
-            let (size,overflowed) = i.overflowing_add(($i).input_len() - input.input_len());
+            let (size,overflowed) = i.overflowing_add($i.input_len() - input.input_len());
             incomplete = ::std::option::Option::Some(
               match overflowed {
                   true  => $crate::Needed::Unknown,
@@ -486,7 +496,7 @@ macro_rules! count(
   ($i:expr, $submac:ident!( $($args:tt)* ), $count: expr) => (
     {
       let ret;
-      let mut input = $i;
+      let mut input = $i.clone();
       let mut res   = ::std::vec::Vec::with_capacity($count);
 
       loop {
@@ -495,7 +505,8 @@ macro_rules! count(
           break;
         }
 
-        match $submac!(input, $($args)*) {
+        let input_ = input.clone();
+        match $submac!(input_, $($args)*) {
           $crate::IResult::Done(i,o) => {
             res.push(o);
             input = i;
@@ -558,7 +569,7 @@ macro_rules! count_fixed (
   ($i:expr, $typ:ty, $submac:ident!( $($args:tt)* ), $count: expr) => (
     {
       let ret;
-      let mut input = $i;
+      let mut input = $i.clone();
       // `$typ` must be Copy, and thus having no destructor, this is panic safe
       let mut res: [$typ; $count] = unsafe{[::std::mem::uninitialized(); $count as usize]};
       let mut cnt: usize = 0;
@@ -761,7 +772,7 @@ macro_rules! fold_many0(
       let ret;
       let f         = $f;
       let mut res   = $init;
-      let mut input = $i;
+      let mut input = $i.clone();
 
       loop {
         if input.input_len() == 0 {
@@ -938,7 +949,7 @@ macro_rules! fold_many_m_n(
       use $crate::InputLength;
       let mut acc          = $init;
       let     f            = $f;
-      let mut input        = $i;
+      let mut input        = $i.clone();
       let mut count: usize = 0;
       let mut err          = false;
       let mut incomplete: ::std::option::Option<$crate::Needed> = ::std::option::Option::None;

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -462,7 +462,8 @@ macro_rules! tuple_parser (
   );
   ($i:expr, $consumed:expr, (), $submac:ident!( $($args:tt)* ), $($rest:tt)*) => (
     {
-      match $submac!($i, $($args)*) {
+      let i_ = $i.clone();
+      match $submac!(i_, $($args)*) {
         $crate::IResult::Error(e)                            =>
           $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) =>
@@ -475,7 +476,8 @@ macro_rules! tuple_parser (
           }
         },
         $crate::IResult::Done(i,o)     => {
-          tuple_parser!(i,
+          let i_ = i.clone();
+          tuple_parser!(i_,
             $consumed + ($crate::InputLength::input_len(&($i)) -
                          $crate::InputLength::input_len(&i)), (o), $($rest)*)
         }
@@ -484,7 +486,8 @@ macro_rules! tuple_parser (
   );
   ($i:expr, $consumed:expr, ($($parsed:tt)*), $submac:ident!( $($args:tt)* ), $($rest:tt)*) => (
     {
-      match $submac!($i, $($args)*) {
+      let i_ = $i.clone();
+      match $submac!(i_, $($args)*) {
         $crate::IResult::Error(e)                            =>
           $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) =>
@@ -497,7 +500,8 @@ macro_rules! tuple_parser (
           }
         },
         $crate::IResult::Done(i,o)     => {
-          tuple_parser!(i,
+          let i_ = i.clone();
+          tuple_parser!(i_,
             $consumed + ($crate::InputLength::input_len(&($i)) -
                          $crate::InputLength::input_len(&i)), ($($parsed)* , o), $($rest)*)
         }
@@ -509,7 +513,8 @@ macro_rules! tuple_parser (
   );
   ($i:expr, $consumed:expr, (), $submac:ident!( $($args:tt)* )) => (
     {
-      match $submac!($i, $($args)*) {
+      let i_ = $i.clone();
+      match $submac!(i_, $($args)*) {
         $crate::IResult::Error(e)                            =>
           $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) =>
@@ -776,7 +781,8 @@ macro_rules! do_parse (
   );
   (__impl $i:expr, $consumed:expr, $submac:ident!( $($args:tt)* ) >> $($rest:tt)*) => (
     {
-      match $submac!($i, $($args)*) {
+      let i_ = $i.clone();
+      match $submac!(i_, $($args)*) {
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) =>
           $crate::IResult::Incomplete($crate::Needed::Unknown),
@@ -788,7 +794,8 @@ macro_rules! do_parse (
           }
         },
         $crate::IResult::Done(i,_)     => {
-          do_parse!(__impl i,
+          let i_ = i.clone();
+          do_parse!(__impl i_,
             $consumed + ($crate::InputLength::input_len(&($i)) -
                          $crate::InputLength::input_len(&i)), $($rest)*)
         },
@@ -802,7 +809,8 @@ macro_rules! do_parse (
 
   (__impl $i:expr, $consumed:expr, $field:ident : $submac:ident!( $($args:tt)* ) >> $($rest:tt)*) => (
     {
-      match  $submac!($i, $($args)*) {
+      let i_ = $i.clone();
+      match  $submac!(i_, $($args)*) {
         $crate::IResult::Error(e)      => $crate::IResult::Error(e),
         $crate::IResult::Incomplete($crate::Needed::Unknown) =>
           $crate::IResult::Incomplete($crate::Needed::Unknown),
@@ -815,7 +823,8 @@ macro_rules! do_parse (
         },
         $crate::IResult::Done(i,o)     => {
           let $field = o;
-          do_parse!(__impl i,
+          let i_ = i.clone();
+          do_parse!(__impl i_,
             $consumed + ($crate::InputLength::input_len(&($i)) -
                          $crate::InputLength::input_len(&i)), $($rest)*)
         },


### PR DESCRIPTION
allows to use non-Copy types with most parsers (by cloning the input at all relevant places)